### PR TITLE
Add slides source to watch dir

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -34,5 +34,6 @@ lazy val slides = project
   .settings(tutSettings: _*)
   .settings(
     tutSourceDirectory := baseDirectory.value / "tut",
-    tutTargetDirectory := baseDirectory.value / "tut-out"
+    tutTargetDirectory := baseDirectory.value / "tut-out",
+    watchSources ++= (tutSourceDirectory.value ** "*.html").get
   ).dependsOn(core)


### PR DESCRIPTION
Allows ~tutQuick to work on changing any html files within the tutSource dir